### PR TITLE
Removed unused parameter ignore_submodels_of, print info instead of error.

### DIFF
--- a/launch/gazebo2marker.launch
+++ b/launch/gazebo2marker.launch
@@ -6,7 +6,5 @@
   <arg name="collision_arg" value="" unless="$(arg collision)" />
 
 
-  <node name="gazebo2marker" pkg="gazebo2rviz" type="gazebo2marker_node.py" args="-f $(arg frequency) $(arg collision_arg)" output="screen">
-    <param name="ignore_submodels_of" value="" type="str" />
-  </node>
+  <node name="gazebo2marker" pkg="gazebo2rviz" type="gazebo2marker_node.py" args="-f $(arg frequency) $(arg collision_arg)" output="screen"/>
 </launch>

--- a/launch/gazebo2tf.launch
+++ b/launch/gazebo2tf.launch
@@ -1,6 +1,4 @@
 <launch>
   <node name="static_tf_pub_world_to_gazebo_world" pkg="tf2_ros" type="static_transform_publisher" args="0 0 0  0 0 0 1 map gazebo_world" />
-  <node name="gazebo2tf" pkg="gazebo2rviz" type="gazebo2tf_node.py" output="screen">
-    <param name="ignore_submodels_of" value="" type="str" />
-  </node>
+  <node name="gazebo2tf" pkg="gazebo2rviz" type="gazebo2tf_node.py" output="screen"/>
 </launch>

--- a/scripts/gazebo2marker_node.py
+++ b/scripts/gazebo2marker_node.py
@@ -72,7 +72,7 @@ def main():
   submodelsToBeIgnored = rospy.get_param('~ignore_submodels_of', '').split(';')
   rospy.loginfo('Ignoring submodels of: ' + str(submodelsToBeIgnored))
   if submodelsToBeIgnored:
-    rospy.logerr('ignore_submodels_of is currently not supported and will thus have no effect')
+    rospy.loginfo('ignore_submodels_of is currently not supported and will thus have no effect')
 
 
   global updatePeriod


### PR DESCRIPTION
The error is printed even when the parameters are removed, therefore I changed it into an info statement. (I want to avoid having errors and warnings printed when the software is launched successfully)