### PR TITLE
removed lifetime parameter from function link2marker_msg

### DIFF
--- a/scripts/gazebo2marker_node.py
+++ b/scripts/gazebo2marker_node.py
@@ -26,7 +26,7 @@ def publish_link_marker(link, full_linkname, **kwargs):
   full_linkinstancename = full_linkname
   if 'model_name' in kwargs and 'instance_name' in kwargs:
     full_linkinstancename = full_linkinstancename.replace(kwargs['model_name'], kwargs['instance_name'], 1)
-  marker_msgs = link2marker_msg(link, full_linkinstancename, use_collision, rospy.Duration(2 * updatePeriod))
+  marker_msgs = link2marker_msg(link, full_linkinstancename, use_collision)
   if len(marker_msgs) > 0:
     for marker_msg in marker_msgs:
       markerPub.publish(marker_msg)

--- a/scripts/sdf2marker_node.py
+++ b/scripts/sdf2marker_node.py
@@ -23,7 +23,7 @@ markers = []
 
 
 def prepare_link_marker(link, full_linkname):
-  marker_msg = link2marker_msg(link, full_linkname, use_collision, rospy.Duration(2 * updatePeriod))
+  marker_msg = link2marker_msg(link, full_linkname, use_collision)
   if marker_msg:
     markers.append(marker_msg)
 

--- a/src/gazebo2rviz/conversions.py
+++ b/src/gazebo2rviz/conversions.py
@@ -23,7 +23,7 @@ supported_geometry_types = ['mesh', 'cylinder', 'sphere', 'box']
 gazebo_rospack = RosPack()
 
 
-def link2marker_msg(link, full_linkname, use_collision = False, lifetime = rospy.Duration(0)):
+def link2marker_msg(link, full_linkname, use_collision = False):
   marker_msg = None
   linkpart = None
   if use_collision:
@@ -42,7 +42,6 @@ def link2marker_msg(link, full_linkname, use_collision = False, lifetime = rospy
     marker_msg = copy.deepcopy(protoMarkerMsg)
     marker_msg.header.frame_id = pysdf.sdf2tfname(full_linkname)
     marker_msg.header.stamp = rospy.get_rostime()
-    marker_msg.lifetime = lifetime
     marker_msg.ns = pysdf.sdf2tfname(full_linkname + "::" + linkpart.name)
     marker_msg.pose = pysdf.homogeneous2pose_msg(linkpart.pose)
 


### PR DESCRIPTION
Setting a lifetime for the markers in rviz was not needed and could cause flickering in the world models. Now the lifetime is removed.